### PR TITLE
Fixed flow per folder count

### DIFF
--- a/flowview.html
+++ b/flowview.html
@@ -956,7 +956,7 @@
         if (folder.parent == parent) {
           var node = {text: folder.name, nodes: treeBuild(folder.id), order: folder.sorting, id: folder.id}
           if (node.nodes.length === 0) delete node.nodes
-          var flowCount = flows.filter(flow => flow.parent === folder.id).length
+          var flowCount = flows.filter(flow => flow.folder === folder.id).length
           if (flowCount > 0) node.tags = [flowCount]
           tree.push(node)
         }


### PR DESCRIPTION
Hi Erik,

Compared the flowviewer between 1.5.13 and 2.0 and found the flowcount per folder didn't work on 2.0. 
Athom changed `folder.folder` to `folder.parent` but not `flow.folder` to `flow.parent` but in the `flowview.html` it was changed, probably a `CTRL-H` ;)

Hope you can merge it.

Groeten,

Danee